### PR TITLE
Added front end parser for sets

### DIFF
--- a/src/Pascal.java
+++ b/src/Pascal.java
@@ -64,7 +64,7 @@ public class Pascal
                     treePrinter.print(iCode);
                 }
 
-                backend.process(iCode, symTabStack);
+//                backend.process(iCode, symTabStack);
             }
         }
         catch (Exception ex) {

--- a/src/wci/frontend/pascal/PascalErrorCode.java
+++ b/src/wci/frontend/pascal/PascalErrorCode.java
@@ -12,6 +12,7 @@ public enum PascalErrorCode
 {
     ALREADY_FORWARDED("Already specified in FORWARD"),
     CASE_CONSTANT_REUSED("CASE constant reused"),
+    EXTRA_COMMA(" Extra Comma"),
     IDENTIFIER_REDEFINED("Redefined identifier"),
     IDENTIFIER_UNDEFINED("Undefined identifier"),
     INCOMPATIBLE_ASSIGNMENT("Incompatible assignment"),
@@ -33,6 +34,7 @@ public enum PascalErrorCode
     INVALID_VAR_PARM("Invalid VAR parameter"),
     MIN_GT_MAX("Min limit greater than max limit"),
     MISSING_BEGIN("Missing BEGIN"),
+    MISSING_CLOSE_SQUARE_BRACKET("Missing close square bracket"),
     MISSING_COLON("Missing :"),
     MISSING_COLON_EQUALS("Missing :="),
     MISSING_COMMA("Missing ,"),

--- a/src/wci/intermediate/icodeimpl/ICodeNodeTypeImpl.java
+++ b/src/wci/intermediate/icodeimpl/ICodeNodeTypeImpl.java
@@ -16,7 +16,7 @@ public enum ICodeNodeTypeImpl implements ICodeNodeType
     PROGRAM, PROCEDURE, FUNCTION,
 
     // Sets
-    SETS,
+    SETS,SUBRANGE,IN_NODE,
     // Statements
     COMPOUND, ASSIGN, LOOP, TEST, CALL, PARAMETERS,
     IF, SELECT, SELECT_BRANCH, SELECT_CONSTANTS, NO_OP,


### PR DESCRIPTION
Line 67 in the main pascal file is commented out. This is because that is the line to run the backend processes.

1. Leave this line commented out and run compile -i to see the tree
-NOTE- Three added nodes-> SETS, SUBRANGE, IN_NODE

- Sets are the generic group not much more

- Subrange is the inner numbers, so if u see <12,Subrange,18>-> that means subrange should be replaced with 13,14,15,16,17-> the subrange node does not have any children and must have generated numbers by executor

- IN_NODE is another relational operator for booleans, The executor needs to understand that part-> Like any boolean the two children of the node are the two paramaters

2. After understanding the parse tree.. edit the executor code! do this by uncommenting the line in the main class. 

3. seterrors.txt- all the errors on the parser side should be fixed and flagged
